### PR TITLE
Revert commit 6ac710f0bbfec2b004795534f3f76a0d1b58e6db for fix error …

### DIFF
--- a/drivers/staging/qcacld-3.0/core/mac/src/sys/legacy/src/utils/src/parser_api.c
+++ b/drivers/staging/qcacld-3.0/core/mac/src/sys/legacy/src/utils/src/parser_api.c
@@ -5910,7 +5910,7 @@ QDF_STATUS populate_dot11f_rrm_ie(struct mac_context *mac,
 
 void populate_mdie(struct mac_context *mac,
 		   tDot11fIEMobilityDomain *pDot11f,
-		   uint8_t mdie[])
+		   uint8_t mdie[SIR_MDIE_SIZE])
 {
 	pDot11f->present = 1;
 	pDot11f->MDID = (uint16_t) ((mdie[1] << 8) | (mdie[0]));


### PR DESCRIPTION
…during compile mdie:

../../../../../../kernel/xiaomi/ginkgo/drivers/staging/qcacld-3.0/core/mac/src/sys/legacy/src/utils/src/parser_api.c:5913:14: error: argument 'mdie' of type 'uint8_t[]' (aka 'unsigned char[] ') with mismatched bound [-Werror,-Warray-parameter]
                   uint8_t mdie[])
                           ^
../../../../../../kernel/xiaomi/ginkgo/drivers/staging/qcacld-3.0/core/mac/src/include/parser_api.h:1028:14: note: previously declared as 'uint8_t[3]' (aka 'unsigned char[3]') here
                   uint8_t mdie[SIR_MDIE_SIZE]);